### PR TITLE
Fix torch dot size limit for KL divergence computation

### DIFF
--- a/weight_formats/experiments/qat.py
+++ b/weight_formats/experiments/qat.py
@@ -200,7 +200,7 @@ def evaluate(model: transformers.PreTrainedModel, task: Task) -> dict[str, Any]:
 # Quantisation-Aware Training
 
 
-def _safe_torch_dot(input: Tensor, other: Tensor, chunk_size=2**32 - 1) -> Tensor:
+def _safe_torch_dot(input: Tensor, other: Tensor, chunk_size=2**31 - 1) -> Tensor:
     """Computes the dot product of two 1D tensors in chunks to avoid size limits."""
     out = torch.tensor(0.0, device=input.device, dtype=input.dtype)
     for i in range(0, len(input), chunk_size):

--- a/weight_formats/experiments/qat.py
+++ b/weight_formats/experiments/qat.py
@@ -200,6 +200,14 @@ def evaluate(model: transformers.PreTrainedModel, task: Task) -> dict[str, Any]:
 # Quantisation-Aware Training
 
 
+def _safe_torch_dot(input: Tensor, other: Tensor, chunk_size=2**32 - 1) -> Tensor:
+    """Computes the dot product of two 1D tensors in chunks to avoid size limits."""
+    out = torch.tensor(0.0, device=input.device, dtype=input.dtype)
+    for i in range(0, len(input), chunk_size):
+        out += torch.dot(input[i : i + chunk_size], other[i : i + chunk_size])
+    return out
+
+
 class XEnt_Destructive(torch.autograd.Function):
     """A somewhat dangerous in-place Cross-Entropy, optimised for memory-efficiency.
 
@@ -212,7 +220,7 @@ class XEnt_Destructive(torch.autograd.Function):
         input_logp = input_logits.sub_(torch.logsumexp(input_logits, -1, keepdim=True))
         del input_logits
         ctx.save_for_backward(input_logp, target_p, mask)
-        return torch.dot(target_p.flatten(), input_logp.flatten()).neg()
+        return _safe_torch_dot(target_p.flatten(), input_logp.flatten()).neg()
 
     @staticmethod
     def backward(ctx, grad_output):
@@ -243,7 +251,9 @@ def _compute_kl_loss(
         )
         reference_p = reference_logp.exp().mul_(mask.unsqueeze(-1))
         # Calculate reference entropy here, so we can free up `reference_logp`
-        reference_ent = torch.dot(reference_p.flatten(), reference_logp.flatten()).neg()
+        reference_ent = _safe_torch_dot(
+            reference_p.flatten(), reference_logp.flatten()
+        ).neg()
         del reference_logp
 
     xent = XEnt_Destructive.apply(

--- a/weight_formats/experiments/tests/test_qat.py
+++ b/weight_formats/experiments/tests/test_qat.py
@@ -8,6 +8,14 @@ from .. import qat
 from ..core import AttrDict
 
 
+def test_safe_torch_dot() -> None:
+    x1 = torch.randn(100)
+    x2 = torch.randn(100)
+    torch.testing.assert_close(
+        qat._safe_torch_dot(x1, x2, chunk_size=16), torch.dot(x1, x2)
+    )
+
+
 @pytest.mark.parametrize("pass_mask", [False, True])
 def test_compute_kl_loss(pass_mask: bool) -> None:
     torch.manual_seed(100)


### PR DESCRIPTION
**Issue**: The maximum length of 1D input tensors for `torch.dot` using CUDA is limited by the largest `int32` number, i.e., `2**31 - 1 = 2,147,483,647`. For example, assuming `bs = 16`, `seq_len = 1024` and `vocab_size = 128,256` (LLama 3), the flattened tensor length is `bs * seq_len * vocab_size = 2,101,346,304`, which is *just* below the maximum.

**Fix**: PR updates the dot product computation to run in `max_len`-sized chunks, avoid the `int32` indexing limit.