### PR TITLE
Add S3D8 format and support for activation quantisation

### DIFF
--- a/weight_formats/experiments/qat.py
+++ b/weight_formats/experiments/qat.py
@@ -423,6 +423,7 @@ def _process_model(model: transformers.PreTrainedModel, test: Test) -> dict[str,
                 if test.error_weight is None
                 else fisher.fetch_fisher(model.config._name_or_path, model.device)
             ),
+            activation_fmt=None,
         )
         return {}
 

--- a/weight_formats/fit.py
+++ b/weight_formats/fit.py
@@ -5,7 +5,7 @@
 import dataclasses
 from dataclasses import dataclass
 from math import log2, prod
-from typing import Any, Literal
+from typing import Any, Literal, TypeAlias
 
 import scipy.optimize
 import torch
@@ -14,6 +14,10 @@ from torch import Tensor
 from . import quantisation as Q
 
 MAX_ROTATION_SIZE = 32768
+
+ElementFamily: TypeAlias = Literal[
+    "int", "fp", "normal", "laplace", "t", "lloyd_max", "s3d8"
+]
 
 
 @dataclass
@@ -27,10 +31,11 @@ class Scaled:
         laplace -- see `Q.crd_laplace` and `Q.crd_block_laplace`
         t -- see `Q.crd_t` and `Q.crd_block_t` (if `df` is specified, disable as search axis)
         lloyd_max -- see `Q.lut_lloyd_max`, e.g. "init", "threshold"
+        s3d8 -- see `Q.scaled_int8_3d8_lloyd_max`
     """
 
     element_bits: float
-    element_family: Literal["int", "fp", "normal", "laplace", "t", "lloyd_max"]
+    element_family: ElementFamily
     scale_format: Q.TensorFormat
     block_shape: Q.BlockShape
     scaling: Q.Scaling
@@ -89,6 +94,8 @@ class Scaled:
             return False
         if self.element_family == "lloyd_max":
             return True
+        if self.element_family == "s3d8":
+            return False
         if self.element_family == "fp" and "exponent_bits" not in self.args:
             return True
         if self.element_family == "t" and "df" not in self.args:
@@ -181,7 +188,7 @@ def _scaled_element_format(
     tensor: Tensor,
     error_weight: Tensor | None,
     element_bits: float,
-    element_family: Literal["int", "fp", "normal", "laplace", "t", "lloyd_max"],
+    element_family: ElementFamily,
     scale_format: Q.TensorFormat,
     block_shape: Q.BlockShape,
     scaling: Q.Scaling,
@@ -245,6 +252,18 @@ def _scaled_element_format(
         return Q.lut_lloyd_max(
             tensor, element_bits, weight=error_weight, range=(-1, 1), **args
         )
+
+    if element_family == "s3d8":
+        assert element_bits == 8 / 3, "s3d8 only supports element_bits=8/3"
+        assert vq_format is None, "s3d8 doesn't support vq_format"
+        assert scaling == "absmax", "s3d8 only supports absmax scaling"
+        # Train a signed VQ[3] int8 quantiser on the normalised tensor
+        args = args.copy()
+        # Default threshold: shorter vectors than general VQ, but still expensive
+        args.setdefault("threshold", 1e-3)
+        return Q.scaled_int8_3d8_lloyd_max(
+            tensor, scale_format=scale_format, block_shape=block_shape, **args
+        ).element_format
 
     FIND_SCALED_FORMAT_STEPS = 17
 

--- a/weight_formats/nearest_neighbour.py
+++ b/weight_formats/nearest_neighbour.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026 Graphcore Ltd. All rights reserved.
+
+"""Nearest neighbour search."""
+
+from typing import Literal
+
+import torch
+import triton
+import triton.language as tl
+from torch import Tensor
+
+
+@triton.jit
+def _kernel__nearest_neighbour_triton(
+    tensor_ptr,
+    centroids_ptr,
+    out_ptr,
+    n,
+    BLOCK_SIZE: tl.constexpr,
+    DIM: tl.constexpr,
+    N_CENTROIDS: tl.constexpr,
+) -> None:
+    pid = tl.program_id(axis=0)
+    offs_n = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask_n = offs_n < n
+
+    best_dist = tl.full([BLOCK_SIZE], float("inf"), dtype=tl.float32)
+    best_idx = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
+    for ic in range(0, N_CENTROIDS):
+        dist = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+        for id in range(0, DIM):
+            x = tl.load(tensor_ptr + DIM * offs_n + id, mask=mask_n, other=0.0)
+            c = tl.load(centroids_ptr + DIM * ic + id)
+            delta = x.to(tl.float32) - c.to(tl.float32)
+            dist += delta * delta
+
+        take = dist < best_dist
+        best_dist = tl.where(take, dist, best_dist)
+        best_idx = tl.where(take, ic, best_idx)
+
+    tl.store(out_ptr + offs_n, best_idx.to(tl.int64), mask=mask_n)
+
+
+_DEFAULT_BLOCK_SIZE = 1024
+
+
+def nearest_neighbour_triton(
+    tensor: Tensor,
+    centroids: Tensor,
+    out: Tensor | None = None,
+    block_size: int = _DEFAULT_BLOCK_SIZE,
+) -> Tensor:
+    n, d = tensor.shape
+    nc, dc = centroids.shape
+    assert dc == d
+    assert tensor.is_cuda and centroids.is_cuda
+
+    if out is None:
+        out = torch.empty((n,), device=tensor.device, dtype=torch.int64)
+    else:
+        assert out.shape == (n,)
+        assert out.device == tensor.device
+        assert out.dtype == torch.int64
+
+    _kernel__nearest_neighbour_triton[(triton.cdiv(n, block_size),)](
+        tensor.contiguous(),
+        centroids.contiguous(),
+        out,
+        n,
+        BLOCK_SIZE=block_size,
+        DIM=d,
+        N_CENTROIDS=nc,
+    )
+    return out
+
+
+_DEFAULT_MAX_BYTES = 8 * 2**30
+
+
+def nearest_neighbour_torch(
+    tensor: Tensor,
+    centroids: Tensor,
+    max_bytes: float | None = _DEFAULT_MAX_BYTES,
+    out: Tensor | None = None,
+) -> Tensor:
+    if out is None:
+        out = torch.empty(tensor.shape[0], device=tensor.device, dtype=torch.int64)
+    chunk_size = (
+        tensor.shape[0]
+        if max_bytes is None
+        else int(max_bytes / (centroids.itemsize * centroids.shape[0]))
+    )
+    for i in range(0, tensor.shape[0], chunk_size):
+        chunk = slice(i, min(tensor.shape[0], i + chunk_size))
+        torch.argmin(
+            torch.cdist(tensor[chunk].to(centroids.dtype), centroids),
+            -1,
+            out=out[chunk],
+        )
+    return out
+
+
+def nearest_neighbour(
+    tensor: Tensor,
+    centroids: Tensor,
+    out: Tensor | None = None,
+    method: Literal["auto", "triton", "torch"] = "auto",
+) -> Tensor:
+    if method == "auto":
+        method = (
+            "triton"
+            if tensor.is_cuda and centroids.is_cuda and centroids.size(-1) <= 256
+            else "torch"
+        )
+    if method == "triton":
+        return nearest_neighbour_triton(tensor, centroids, out=out)
+    elif method == "torch":
+        return nearest_neighbour_torch(tensor, centroids, out=out)
+    else:
+        raise ValueError(f"Unknown nearest_neighbour method: {method}")

--- a/weight_formats/nearest_neighbour.py
+++ b/weight_formats/nearest_neighbour.py
@@ -5,40 +5,47 @@
 from typing import Literal
 
 import torch
-import triton
-import triton.language as tl
 from torch import Tensor
 
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+    tl = None
 
-@triton.jit
-def _kernel__nearest_neighbour_triton(
-    tensor_ptr,
-    centroids_ptr,
-    out_ptr,
-    n,
-    BLOCK_SIZE: tl.constexpr,
-    DIM: tl.constexpr,
-    N_CENTROIDS: tl.constexpr,
-) -> None:
-    pid = tl.program_id(axis=0)
-    offs_n = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask_n = offs_n < n
 
-    best_dist = tl.full([BLOCK_SIZE], float("inf"), dtype=tl.float32)
-    best_idx = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
-    for ic in range(0, N_CENTROIDS):
-        dist = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
-        for id in range(0, DIM):
-            x = tl.load(tensor_ptr + DIM * offs_n + id, mask=mask_n, other=0.0)
-            c = tl.load(centroids_ptr + DIM * ic + id)
-            delta = x.to(tl.float32) - c.to(tl.float32)
-            dist += delta * delta
+if triton is not None:
 
-        take = dist < best_dist
-        best_dist = tl.where(take, dist, best_dist)
-        best_idx = tl.where(take, ic, best_idx)
+    @triton.jit
+    def _kernel__nearest_neighbour_triton(
+        tensor_ptr,
+        centroids_ptr,
+        out_ptr,
+        n,
+        BLOCK_SIZE: tl.constexpr,
+        DIM: tl.constexpr,
+        N_CENTROIDS: tl.constexpr,
+    ) -> None:
+        pid = tl.program_id(axis=0)
+        offs_n = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask_n = offs_n < n
 
-    tl.store(out_ptr + offs_n, best_idx.to(tl.int64), mask=mask_n)
+        best_dist = tl.full([BLOCK_SIZE], float("inf"), dtype=tl.float32)
+        best_idx = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
+        for ic in range(0, N_CENTROIDS):
+            dist = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+            for id in range(0, DIM):
+                x = tl.load(tensor_ptr + DIM * offs_n + id, mask=mask_n, other=0.0)
+                c = tl.load(centroids_ptr + DIM * ic + id)
+                delta = x.to(tl.float32) - c.to(tl.float32)
+                dist += delta * delta
+
+            take = dist < best_dist
+            best_dist = tl.where(take, dist, best_dist)
+            best_idx = tl.where(take, ic, best_idx)
+
+        tl.store(out_ptr + offs_n, best_idx.to(tl.int64), mask=mask_n)
 
 
 _DEFAULT_BLOCK_SIZE = 1024
@@ -50,6 +57,9 @@ def nearest_neighbour_triton(
     out: Tensor | None = None,
     block_size: int = _DEFAULT_BLOCK_SIZE,
 ) -> Tensor:
+    if triton is None:
+        raise ImportError("triton is required for method='triton'")
+
     n, d = tensor.shape
     nc, dc = centroids.shape
     assert dc == d
@@ -109,7 +119,12 @@ def nearest_neighbour(
     if method == "auto":
         method = (
             "triton"
-            if tensor.is_cuda and centroids.is_cuda and centroids.size(-1) <= 256
+            if (
+                triton is not None
+                and tensor.is_cuda
+                and centroids.is_cuda
+                and centroids.size(-1) <= 256
+            )
             else "torch"
         )
     if method == "triton":

--- a/weight_formats/quantisation.py
+++ b/weight_formats/quantisation.py
@@ -508,6 +508,63 @@ class VectorLUTFormat(ScalarFormat):
         return values[idx].view(x.shape).to(x.dtype)
 
 
+@dataclass
+class Sign3D8Format(ScalarFormat):
+    """A format for 2D tensors, which stores 3-vectors along rows in 8 bits / 3 values.
+
+    Each 3-vector is quantised to a 5-bit LUT index for the absolute value,
+    and the sign of each value is stored separately.
+
+    Note that this is not truly a scalar format (and does not support .bits), but
+    is marked as a `ScalarFormat` so that it can be used with `LinearScalingFormat`.
+    """
+
+    lut: VectorLUTFormat
+    _type: str = "s3d8"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.lut, VectorLUTFormat):
+            raise ValueError("Sign3D8Format requires a VectorLUTFormat for `lut`")
+        if len(self.lut.values) != 32 or any(len(v) != 3 for v in self.lut.values):
+            raise ValueError("Sign3D8Format requires LUT with shape (32, 3)")
+
+    def __str__(self) -> str:
+        return f"Sign3D8{{{self.lut}}}"
+
+    @staticmethod
+    def vectorise(tensor: Tensor) -> Tensor:
+        rows, _ = tensor.shape
+        return torch.nn.functional.pad(tensor.T, (0, -(rows % -3))).reshape(-1, 3)
+
+    @staticmethod
+    def unvectorise(vectors: Tensor, shape: Shape) -> Tensor:
+        rows, cols = shape
+        return vectors.reshape(cols, -1)[:, :rows].T.reshape(shape)
+
+    def count_bits(self, shape: Shape) -> int:
+        rows, cols = shape
+        rows += -(rows % -3)  # padding
+        return self.lut.count_bits((rows, cols)) + rows * cols  # = abs + sign
+
+    @property
+    def range(self) -> tuple[float, float]:
+        _, lut_max = self.lut.range
+        return (-lut_max, lut_max)
+
+    @property
+    def bits(self) -> float:
+        raise NotImplementedError("Sign3D8Format does not implement `bits`")
+
+    def quantise(self, tensor: Tensor) -> Tensor:
+        if tensor.ndim != 2:
+            raise ValueError(
+                f"Sign3D8Format only supports rank-2 inputs (actual rank: {tensor.ndim})"
+            )
+        q = self.vectorise(tensor)
+        q = torch.copysign(self.lut.quantise(q.abs()), q)
+        return self.unvectorise(q, tensor.shape)
+
+
 # Lloyd-Max
 
 
@@ -1436,6 +1493,41 @@ class CompressedLUTFormat(CompressedTensorFormat):
         return cls.train(
             lut_grid(resolution, data.abs().amax().item()), data=data, **args
         )
+
+
+# Factories
+
+
+def scaled_int8_3d8_lloyd_max(
+    tensor: Tensor,
+    scale_format: TensorFormat,
+    block_shape: BlockShape,
+    threshold: float,
+    **args: Any,
+) -> LinearScalingFormat:
+    if tensor.ndim != 2:
+        raise ValueError(
+            f"scaled_int8_3d8_lloyd_max expects a rank-2 tensor, actual {tensor.ndim}"
+        )
+    element_type, scaling = TorchFormat(torch.int8), "absmax"
+    q_i8 = element_type.quantise(
+        block_normalise(
+            tensor,
+            block_shape=block_shape,
+            scaling=scaling,
+            element_range=element_type.range,
+            scale_format=scale_format,
+        )[0]
+    )
+    vfmt = vlut_lloyd_max(
+        Sign3D8Format.vectorise(q_i8).abs(),
+        bits=5 / 3,
+        range=(0, 127),
+        threshold=threshold,
+        element_type=element_type,
+        **args,
+    )
+    return LinearScalingFormat(Sign3D8Format(vfmt), scale_format, block_shape, scaling)
 
 
 # Type index

--- a/weight_formats/quantisation.py
+++ b/weight_formats/quantisation.py
@@ -19,6 +19,8 @@ import torch
 import tqdm
 from torch import Tensor
 
+from .nearest_neighbour import nearest_neighbour
+
 Shape = Tuple[int, ...]
 
 # Utilities
@@ -415,32 +417,6 @@ class LUTFormat(ScalarFormat):
         return values[self.to_idx(x)]
 
 
-NEAREST_NEIGHBOUR_DEFAULT_MAX_BYTES = 8 * 2**30
-
-
-def _nearest_neighbour(
-    tensor: Tensor,
-    centroids: Tensor,
-    max_bytes: float | None = NEAREST_NEIGHBOUR_DEFAULT_MAX_BYTES,
-    out: Tensor | None = None,
-) -> Tensor:
-    if out is None:
-        out = torch.empty(tensor.shape[0], device=tensor.device, dtype=torch.int64)
-    chunk_size = (
-        tensor.shape[0]
-        if max_bytes is None
-        else int(max_bytes / (centroids.itemsize * centroids.shape[0]))
-    )
-    for i in builtins.range(0, tensor.shape[0], chunk_size):
-        chunk = slice(i, min(tensor.shape[0], i + chunk_size))
-        torch.argmin(
-            torch.cdist(tensor[chunk].to(centroids.dtype), centroids),
-            -1,
-            out=out[chunk],
-        )
-    return out
-
-
 @dataclass
 class VectorLUTFormat(ScalarFormat):
     """A Vector Quantisation (VQ) format via lookup table.
@@ -504,7 +480,7 @@ class VectorLUTFormat(ScalarFormat):
         values = self.element_type.quantise(
             torch.tensor(self.values, device=x.device, dtype=torch.float32)
         )
-        idx = _nearest_neighbour(x.view(-1, self.dim), values)
+        idx = nearest_neighbour(x.view(-1, self.dim), values)
         return values[idx].view(x.shape).to(x.dtype)
 
 
@@ -717,7 +693,7 @@ def _vector_lloyd_max_init(
         for i in range(0, n_centroids, step):
             n = min(step, n_centroids - i)
             centroids[i : i + n] = s[torch.multinomial(p / p.sum(), n)]
-            idx = _nearest_neighbour(s, centroids[: i + n])
+            idx = nearest_neighbour(s, centroids[: i + n])
             p = (s - centroids[idx]).pow(2).sum(-1)
         return centroids
     else:
@@ -759,7 +735,7 @@ def vlut_lloyd_max(
     tqdm_ = tqdm.tqdm(it.count(), disable=not progress)
     for _ in tqdm_:
         last_idx[:n] = idx[:n]
-        _nearest_neighbour(tensor[:n], centroids, out=idx[:n])
+        nearest_neighbour(tensor[:n], centroids, out=idx[:n])
         centroids.scatter_reduce_(
             0,
             idx[:n, None].expand(-1, dim),

--- a/weight_formats/quantisation_training.py
+++ b/weight_formats/quantisation_training.py
@@ -3,12 +3,12 @@
 """Core utilities for quantisation-aware training."""
 
 import copy
-import dataclasses
 import json
 import math
-from typing import Any, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 import torch
+import tqdm
 from torch import Tensor, nn
 
 from . import fit as F
@@ -51,6 +51,32 @@ class Quantise_STE(torch.autograd.Function):
             gcentroids = gcentroids.to(centroids.dtype)
 
         return (gx, gcentroids, None)
+
+
+class Quantise_Vector_STE(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x: Tensor, centroids: Tensor) -> Tensor:
+        idx = Q._nearest_neighbour(x, centroids)
+        ctx.x_requires_grad = x.requires_grad
+        ctx.centroids_requires_grad = centroids.requires_grad
+        if centroids.requires_grad:
+            ctx.save_for_backward(idx, centroids)
+        return centroids[idx].to(x.dtype)
+
+    @staticmethod
+    def backward(ctx, gy: Tensor) -> tuple[Tensor, Tensor]:
+        gx = gy if ctx.x_requires_grad else None
+
+        if not ctx.centroids_requires_grad:
+            gcentroids = None
+        else:
+            idx, centroids = ctx.saved_tensors
+            gcentroids = torch.zeros_like(centroids, dtype=torch.float32)
+            gcentroids.index_add_(
+                0, idx.flatten(), gy.reshape(-1, centroids.shape[1]).float()
+            )
+            gcentroids = gcentroids.to(centroids.dtype)
+        return (gx, gcentroids)
 
 
 ScalingMode: TypeAlias = Literal["parameter", "dynamic"]
@@ -112,6 +138,7 @@ class Weight(nn.Module):
                 dtype=self.master.dtype,
             )
         )
+        assert self.centroids.ndim == 1, "Weight() only supports 1D centroids"
         self._blocked_shape = Q.blocked_shape(self.master, scaling_fmt.block_shape)
         if scaling_mode == "parameter":
             scale = Q.blocked_scale(
@@ -198,6 +225,91 @@ class Weight(nn.Module):
         return ", ".join(map(str, self.shape))
 
 
+class Sign3D8Weight(nn.Module):
+    @staticmethod
+    def is_supported(fmt: Q.TensorFormat) -> bool:
+        return isinstance(fmt, Q.LinearScalingFormat) and isinstance(
+            fmt.element_format, Q.Sign3D8Format
+        )
+
+    def __init__(
+        self,
+        weight: Tensor,
+        fmt: Q.LinearScalingFormat,
+        scaling_mode: ScalingMode,
+    ):
+        super().__init__()
+        self.fmt = fmt
+        self.scaling_mode = scaling_mode
+        self.master = nn.Parameter(weight)
+        self._blocked_shape = Q.blocked_shape(self.master, fmt.block_shape)
+        # Centroids are untrainable as we don't support requantisation using element_type
+        self.centroids = nn.Parameter(
+            fmt.element_format.lut.element_type.quantise(
+                torch.tensor(
+                    fmt.element_format.lut.values,
+                    device=self.master.device,
+                    dtype=torch.float32,
+                )
+            ),
+            requires_grad=False,
+        )
+        self._element_value_bits = fmt.element_format.lut.element_type.bits
+        self._scale_format = fmt.scale_format
+        if scaling_mode == "parameter":
+            scale = Q.blocked_scale(
+                self.master.reshape(self._blocked_shape),
+                scaling=fmt.scaling,
+                element_range=fmt.element_format.range,
+            )
+            # Scale is untrainable as we don't support grad clipping
+            self.scale = nn.Parameter(
+                fmt.scale_format.quantise(_squeeze_odd_dims(scale)), requires_grad=False
+            )
+        elif scaling_mode == "dynamic":
+            self._scaling = fmt.scaling
+            self._element_range = fmt.element_format.range
+        else:
+            assert False, f"Unknown scaling_mode={scaling_mode!r}"
+
+    @property
+    def shape(self) -> torch.Size:
+        return self.master.shape
+
+    def count_bits(self, compute_dtype: torch.dtype) -> float:
+        rows, cols = self.master.shape
+        bits = cols * 8 * ((rows + 2) // 3)
+        bits += self._scale_format.count_bits(self._blocked_shape[::2])
+        bits += self.centroids.nelement() * self._element_value_bits
+        return bits
+
+    def _get_scale(self) -> Tensor:
+        if self.scaling_mode == "parameter":
+            return _unsqueeze_odd_dims(self.scale)
+        scale = Q.blocked_scale(
+            self.master.reshape(self._blocked_shape),
+            self._scaling,
+            self._element_range,
+        )
+        return self._scale_format.quantise(scale)
+
+    @torch.compiler.disable()
+    def forward(self) -> Tensor:
+        shape, scale = self.shape, self._get_scale()
+        weight = Q.safe_div(self.master.reshape(self._blocked_shape), scale).reshape(
+            shape
+        )
+        weight = Q.Sign3D8Format.vectorise(weight)
+        weight = Quantise_Vector_STE.apply(weight.abs(), self.centroids).copysign(
+            weight
+        )
+        weight = Q.Sign3D8Format.unvectorise(weight, shape)
+        return weight.reshape(self._blocked_shape).mul(scale).reshape(shape)
+
+    def extra_repr(self) -> str:
+        return ", ".join(map(str, self.shape))
+
+
 class UnquantisedWeight(nn.Module):
     def __init__(self, weight: Tensor):
         super().__init__()
@@ -210,7 +322,7 @@ class UnquantisedWeight(nn.Module):
 class Linear(nn.Module):
     def __init__(
         self,
-        weight: Weight | UnquantisedWeight,
+        weight: Weight | Sign3D8Weight | UnquantisedWeight,
         bias: nn.Parameter | None,
         activation_fmt: Q.TensorFormat | None,
     ):
@@ -246,11 +358,13 @@ def convert(
     error_weight: dict[str, Tensor] | None,
     activation_fmt: Q.TensorFormat | None,
     mode: Literal["qat", "one-shot"] = "qat",
+    progress: bool = False,
 ) -> None:
     """Recursively convert `module` to a trainable quantised model."""
 
     shared_weights = {}
     visited_modules = set([])
+    tqdm_ = tqdm.tqdm(disable=not progress, desc="Quantising")
 
     def _visit(parent: nn.Module, prefix: tuple[str, ...]) -> None:
         if parent in visited_modules:
@@ -284,6 +398,8 @@ def convert(
 
             # Substitute `child` to use a `Weight` module
             if replace_cls:
+                tqdm_.update(1)
+                tqdm_.set_postfix_str('.'.join(prefix + (name,)))
                 if child.weight in shared_weights:
                     # Copy the module, then share the parameters individually
                     src = shared_weights[child.weight]
@@ -308,7 +424,11 @@ def convert(
                         )
                     else:
                         # Construct quantised weight
-                        weight = Weight(child.weight, fmt, scaling_mode, clip_gradient)
+                        weight = (
+                            Sign3D8Weight(child.weight, fmt, scaling_mode)
+                            if Sign3D8Weight.is_supported(fmt)
+                            else Weight(child.weight, fmt, scaling_mode, clip_gradient)
+                        )
 
                         if mode == "one-shot":
                             with torch.no_grad():
@@ -320,6 +440,7 @@ def convert(
                 parent.add_module(name, replace_cls(weight, **replace_args))
 
     _visit(module, ())
+    tqdm_.close()
     module._quantisation_args = dict(
         activation_fmt=activation_fmt,
         scaling_mode=scaling_mode,
@@ -340,7 +461,7 @@ def get_named_parameters(
     results = []
     visited: set[nn.Parameter] = set([])
     for mname, m in module.named_modules():
-        if isinstance(m, Weight):
+        if isinstance(m, (Weight, Sign3D8Weight)):
             for n, p in m._parameters.items():
                 pkind = dict(
                     master="weight",
@@ -366,7 +487,7 @@ def count_bits(
     total = 0
     visited = set()
     for m in module.modules():
-        if isinstance(m, Weight):
+        if isinstance(m, (Weight, Sign3D8Weight)):
             if set(m.parameters()) - visited:
                 total += m.count_bits(compute_dtype)
                 visited |= set(m.parameters())
@@ -383,7 +504,7 @@ def count_parameters(module: nn.Module, include_other: bool = True) -> int:
     total = 0
     visited = set()
     for m in module.modules():
-        if isinstance(m, Weight):
+        if isinstance(m, (Weight, Sign3D8Weight)):
             if set(m.parameters()) - visited:
                 total += math.prod(m.shape)
                 visited |= set(m.parameters())
@@ -419,7 +540,7 @@ def save(module: nn.Module) -> dict[str, Tensor]:
     meta["fmt"] = {}
     for k, m in module.named_modules():
         k = k.replace("._orig_mod", "")
-        if isinstance(m, Weight):
+        if isinstance(m, (Weight, Sign3D8Weight)):
             meta["fmt"][k] = Q.TensorFormat.save(m.fmt)
         if isinstance(m, UnquantisedWeight):
             meta["fmt"][k] = Q.TensorFormat.save(Q.BFLOAT16)

--- a/weight_formats/quantisation_training.py
+++ b/weight_formats/quantisation_training.py
@@ -11,6 +11,7 @@ import torch
 import tqdm
 from torch import Tensor, nn
 
+from .nearest_neighbour import nearest_neighbour
 from . import fit as F
 from . import quantisation as Q
 
@@ -56,7 +57,7 @@ class Quantise_STE(torch.autograd.Function):
 class Quantise_Vector_STE(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x: Tensor, centroids: Tensor) -> Tensor:
-        idx = Q._nearest_neighbour(x, centroids)
+        idx = nearest_neighbour(x, centroids)
         ctx.x_requires_grad = x.requires_grad
         ctx.centroids_requires_grad = centroids.requires_grad
         if centroids.requires_grad:

--- a/weight_formats/quantisation_training.py
+++ b/weight_formats/quantisation_training.py
@@ -208,12 +208,21 @@ class UnquantisedWeight(nn.Module):
 
 
 class Linear(nn.Module):
-    def __init__(self, weight: Weight | UnquantisedWeight, bias: nn.Parameter | None):
+    def __init__(
+        self,
+        weight: Weight | UnquantisedWeight,
+        bias: nn.Parameter | None,
+        activation_fmt: Q.TensorFormat | None,
+    ):
         super().__init__()
         self.weight = weight
         self.bias = bias
+        self.activation_fmt = activation_fmt
 
     def forward(self, input: Tensor) -> Tensor:
+        if self.activation_fmt is not None:
+            q = self.activation_fmt.quantise(input.flatten(end_dim=-2)).view_as(input)
+            input = input + (q - input).detach()  # STE
         return nn.functional.linear(input, self.weight(), self.bias)
 
 
@@ -235,6 +244,7 @@ def convert(
     scaling_mode: ScalingMode,
     clip_gradient: bool,
     error_weight: dict[str, Tensor] | None,
+    activation_fmt: Q.TensorFormat | None,
     mode: Literal["qat", "one-shot"] = "qat",
 ) -> None:
     """Recursively convert `module` to a trainable quantised model."""
@@ -259,9 +269,10 @@ def convert(
                     raise ValueError(f"Cannot convert {type(child)}")
                 replace_cls = Linear
                 replace_args = dict(
+                    activation_fmt=activation_fmt,
                     bias=(
                         None if child.bias is None else nn.Parameter(child.bias.clone())
-                    )
+                    ),
                 )
             if isinstance(child, nn.Embedding):
                 if type(child) != nn.Embedding or not (child.max_norm is None):
@@ -310,7 +321,9 @@ def convert(
 
     _visit(module, ())
     module._quantisation_args = dict(
-        scaling_mode=scaling_mode, clip_gradient=clip_gradient
+        activation_fmt=activation_fmt,
+        scaling_mode=scaling_mode,
+        clip_gradient=clip_gradient,
     )
 
 
@@ -400,7 +413,10 @@ def save(module: nn.Module) -> dict[str, Tensor]:
     state_dict = {
         k.replace("._orig_mod", ""): v for k, v in module.state_dict().items()
     }
-    meta = dict(fmt={}, **module._quantisation_args.copy())
+    meta = module._quantisation_args.copy()
+    if meta["activation_fmt"] is not None:
+        meta["activation_fmt"] = Q.TensorFormat.save(meta["activation_fmt"])
+    meta["fmt"] = {}
     for k, m in module.named_modules():
         k = k.replace("._orig_mod", "")
         if isinstance(m, Weight):
@@ -417,6 +433,10 @@ def load_convert(module: nn.Module, state: dict[str, Tensor]) -> None:
     """Load and convert a module to a quantised version."""
     state = state.copy()
     meta = json.loads(state.pop("_quantisation_meta").numpy().tobytes())
+    if meta.get("activation_fmt") is not None:
+        meta["activation_fmt"] = Q.TensorFormat.load(meta["activation_fmt"])
+    else:
+        meta["activation_fmt"] = None
     fmt = {k: Q.TensorFormat.load(s) for k, s in meta.pop("fmt").items()}
     convert(module, fmt_spec=fmt, **meta, error_weight=None)
     module.load_state_dict(state)

--- a/weight_formats/tests/test_fit.py
+++ b/weight_formats/tests/test_fit.py
@@ -63,3 +63,19 @@ def test_scaled() -> None:
             actual_b = fmt.count_bits_tensor(x) / x.nelement()
             assert expected_b - tol < actual_b < expected_b + tol
             assert Q.qrmse_norm(fmt, x).item() < 0.12  # empirical
+
+
+def test_scaled_s3d8() -> None:
+    torch.manual_seed(100)
+    x = torch.randn(64, 128).mul(1000).bfloat16()
+    fmt = F.Scaled(
+        element_bits=8 / 3,
+        element_family="s3d8",
+        scale_format=Q.BFLOAT16,
+        block_shape=(1, None),
+        scaling="absmax",
+        args=dict(threshold=1e-2),
+    ).fit(x)
+    assert isinstance(fmt, Q.LinearScalingFormat)
+    assert isinstance(fmt.element_format, Q.Sign3D8Format)
+    assert 0.15 < Q.qrmse_norm(fmt, x).item() < 0.25  # empirical

--- a/weight_formats/tests/test_nearest_neighbour.py
+++ b/weight_formats/tests/test_nearest_neighbour.py
@@ -1,0 +1,23 @@
+import pytest
+import torch
+
+from .. import nearest_neighbour
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("n,d,nc", [(4096, 3, 32), (83, 8, 17), (1024, 4, 64)])
+def test_nearest_neighbour_matches_cdist(n: int, d: int, nc: int) -> None:
+    device = torch.device("cuda:0")
+    torch.manual_seed(100)
+    tensor = torch.randn(n, d, device=device, dtype=torch.float32)
+    centroids = torch.randn(nc, d, device=device, dtype=torch.float32)
+
+    expected = torch.cdist(tensor, centroids).argmin(-1)
+
+    for method in ["triton", "torch"]:
+        out = nearest_neighbour.nearest_neighbour(tensor, centroids, method=method)
+        torch.testing.assert_close(out, expected)
+
+        out.fill_(-1)
+        nearest_neighbour.nearest_neighbour(tensor, centroids, out=out, method=method)
+        torch.testing.assert_close(out, expected)

--- a/weight_formats/tests/test_quantisation.py
+++ b/weight_formats/tests/test_quantisation.py
@@ -295,3 +295,22 @@ def test_compressed_lut_format() -> None:
     )
     torch.testing.assert_close(fmt.quantise(tensor([-3, 1.2])), tensor([-2.0, 1]))
     assert fmt.count_bits_tensor(tensor([0, 0, 0, 0, 3])) == 4 * 1 + 3
+
+
+def test_scaled_int8_3d8_lloyd_max_format() -> None:
+    torch.manual_seed(100)
+    x = torch.randn(256, 128)
+
+    fmt = Q.scaled_int8_3d8_lloyd_max(x, Q.BFLOAT16, (1, None), threshold=1e-2)
+
+    scale_bits = 256 * 16
+    data_bits = (256 + 2) // 3 * 128 * 8
+    table_bits = 8 * 32 * 3
+    assert fmt.count_bits_tensor(x) == scale_bits + data_bits + table_bits
+
+    q = fmt.quantise(x)
+    assert q.shape == x.shape
+    assert 0.15 < Q.qrmse_norm(fmt, x).item() < 0.25  # empirical
+
+    fmt_reloaded = Q.TensorFormat.load(json.loads(json.dumps(Q.TensorFormat.save(fmt))))
+    torch.testing.assert_close(fmt_reloaded.quantise(x), q)

--- a/weight_formats/tests/test_quantisation.py
+++ b/weight_formats/tests/test_quantisation.py
@@ -221,9 +221,9 @@ def test_lloyd_max_crd() -> None:
 def test_vlut_lloyd_max() -> None:
     torch.manual_seed(100)
     x = torch.distributions.StudentT(5).sample((2**16,))
-    sfmt = Q.lut_lloyd_max(x, 2, 10**-3)
+    sfmt = Q.lut_lloyd_max(x, 3, 10**-3)
     for init in ["random", "kmeans++"]:
-        vfmt = Q.vlut_lloyd_max(x.view(-1, 2), 2, 10**-3, Q.BFLOAT16, init=init)
+        vfmt = Q.vlut_lloyd_max(x.view(-1, 2), 3, 10**-3, Q.BFLOAT16, init=init)
         assert Q.qrmse_norm(vfmt, x).item() < Q.qrmse_norm(sfmt, x).item() - 0.01, init
 
 

--- a/weight_formats/tests/test_quantisation_training.py
+++ b/weight_formats/tests/test_quantisation_training.py
@@ -10,6 +10,14 @@ from .. import quantisation as Q
 from .. import quantisation_training as T
 
 
+CHANNEL_ABSMAX_INT8 = Q.LinearScalingFormat(
+    Q.IntFormat(8),
+    scale_format=Q.BFLOAT16,
+    block_shape=(1, None),
+    scaling="absmax",
+)
+
+
 def test_quantise_ste() -> None:
     x = tensor([0.0, 0.2, 0.4, 0.6, 0.8, 1.0, -0.2, -0.4, 1.2, 1.4]).requires_grad_()
     ex = tensor([0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0])
@@ -126,8 +134,40 @@ def test_convert_embedding() -> None:
         "dynamic",
         clip_gradient=False,
         error_weight=None,
+        activation_fmt=None,
     )
     assert model(input).shape == (5, 16)
+
+
+def test_convert_linear_with_activation_quantisation() -> None:
+    torch.manual_seed(100)
+    reference = nn.Sequential(nn.Linear(64, 32, bias=True))
+    model = copy.deepcopy(reference)
+    input = torch.randn(8, 16, 64).requires_grad_()
+
+    T.convert(
+        model,
+        Q.BFLOAT16,
+        "dynamic",
+        clip_gradient=False,
+        activation_fmt=CHANNEL_ABSMAX_INT8,
+        error_weight=None,
+    )
+
+    output = model(input)
+    reference_input = (
+        CHANNEL_ABSMAX_INT8.quantise(input.view(-1, 64))
+        .view_as(input)
+        .detach()
+        .clone()
+        .requires_grad_()
+    )
+    reference_output = reference(reference_input)
+    output.square().mean().backward()
+    reference_output.square().mean().backward()
+
+    torch.testing.assert_close(output, reference_output)
+    torch.testing.assert_close(input.grad, reference_input.grad)
 
 
 def test_convert_and_train() -> None:
@@ -157,6 +197,7 @@ def test_convert_and_train() -> None:
         scaling_mode="parameter",
         clip_gradient=True,
         error_weight=None,
+        activation_fmt=CHANNEL_ABSMAX_INT8,
     )
 
     bpp = T.count_bits(model, torch.bfloat16) / T.count_parameters(model)
@@ -203,6 +244,7 @@ def test_convert_perturb_only() -> None:
         "dynamic",
         clip_gradient=False,
         error_weight=None,
+        activation_fmt=None,
     )
     T.convert(
         model_os,
@@ -211,6 +253,7 @@ def test_convert_perturb_only() -> None:
         clip_gradient=False,
         error_weight=None,
         mode="one-shot",
+        activation_fmt=None,
     )
     input = torch.randn(2048, 64)
 

--- a/weight_formats/tests/test_quantisation_training.py
+++ b/weight_formats/tests/test_quantisation_training.py
@@ -2,6 +2,7 @@
 
 import copy
 
+import pytest
 import torch
 from torch import nn, tensor
 
@@ -9,9 +10,26 @@ from .. import fit as F
 from .. import quantisation as Q
 from .. import quantisation_training as T
 
-
 CHANNEL_ABSMAX_INT8 = Q.LinearScalingFormat(
     Q.IntFormat(8),
+    scale_format=Q.BFLOAT16,
+    block_shape=(1, None),
+    scaling="absmax",
+)
+
+SIGN_3D8 = Q.LinearScalingFormat(
+    Q.Sign3D8Format(
+        Q.VectorLUTFormat.create(
+            torch.cartesian_prod(  # dummy => (32, 3)
+                torch.linspace(0, 127, 4),
+                torch.linspace(0, 127, 4),
+                torch.linspace(0, 127, 2),
+            ),
+            Q.TorchFormat(torch.int8),
+            "S3D8",
+            range=(0, 127),
+        )
+    ),
     scale_format=Q.BFLOAT16,
     block_shape=(1, None),
     scaling="absmax",
@@ -124,6 +142,26 @@ def test_weight_gradients() -> None:
     assert weight.sparse_weight.grad.equal(torch.full((3,), 1.0))
 
 
+@pytest.mark.parametrize("scaling_mode", ["parameter", "dynamic"])
+def test_sign_3d8_weight_matches_format(scaling_mode: str) -> None:
+    torch.manual_seed(100)
+    reference_weight = torch.randn(32, 64).mul(0.01).bfloat16()
+    weight = T.Sign3D8Weight(reference_weight, SIGN_3D8, scaling_mode=scaling_mode)
+    weight.centroids.requires_grad_(False)
+    weight().pow(2).sum().backward()
+
+    torch.testing.assert_close(
+        weight(), SIGN_3D8.quantise(reference_weight)#, atol=atol, rtol=0
+    )
+    assert weight.count_bits(torch.bfloat16) == SIGN_3D8.count_bits(
+        reference_weight.shape
+    )
+    assert weight.master.grad is not None and weight.master.grad.abs().sum() > 0
+    if hasattr(weight, "scale"):
+        assert weight.scale.grad is None
+    assert weight.centroids.grad is None
+
+
 def test_convert_embedding() -> None:
     torch.manual_seed(100)
     model = nn.Embedding(100, 16, padding_idx=0)
@@ -230,6 +268,35 @@ def test_convert_and_train() -> None:
     T.load_convert(reloaded, T.save(model))
     torch.testing.assert_close(reloaded(input), model(input))
     assert T.count_bits(reloaded, torch.bfloat16) == T.count_bits(model, torch.bfloat16)
+
+
+def test_convert_and_train_sign_3d8() -> None:
+    torch.manual_seed(100)
+    reference = nn.Sequential(nn.Linear(128, 16, bias=False))
+    model = copy.deepcopy(reference)
+    T.convert(
+        model,
+        SIGN_3D8,
+        "parameter",
+        clip_gradient=False,
+        error_weight=None,
+        activation_fmt=None,
+    )
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    input = torch.randn(64, 128)
+    losses = []
+    for _ in range(3):
+        opt.zero_grad()
+        loss = torch.nn.functional.mse_loss(model(input), reference(input))
+        loss.backward()
+        opt.step()
+        losses.append(loss.item())
+
+    assert losses[-1] < losses[0]
+
+    reloaded = copy.deepcopy(reference)
+    T.load_convert(reloaded, T.save(model))
+    torch.testing.assert_close(reloaded(input), model(input))
 
 
 def test_convert_perturb_only() -> None:


### PR DESCRIPTION
Includes:
 - Activation quantisation for QAT of Linear layers
 - New "s3d8" format - Q.Sign3D8Format for the signed-absolute-vector & padding support, F.Scaled("s3d8", ...) for fitting the format, `T.Sign3D8Weight` for QAT.

E.g.

```python
fmt = F.Scaled(
    8 / 3,
    "s3d8",
    scale_format=Q.BFLOAT16,
    block_shape=(1, None),
    scaling="absmax",
    args=dict(threshold=1e-3),
)
```
