### PR TITLE
Small workaround if triton unavailable

### DIFF
--- a/weight_formats/nearest_neighbour.py
+++ b/weight_formats/nearest_neighbour.py
@@ -5,40 +5,47 @@
 from typing import Literal
 
 import torch
-import triton
-import triton.language as tl
 from torch import Tensor
 
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+    tl = None
 
-@triton.jit
-def _kernel__nearest_neighbour_triton(
-    tensor_ptr,
-    centroids_ptr,
-    out_ptr,
-    n,
-    BLOCK_SIZE: tl.constexpr,
-    DIM: tl.constexpr,
-    N_CENTROIDS: tl.constexpr,
-) -> None:
-    pid = tl.program_id(axis=0)
-    offs_n = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask_n = offs_n < n
 
-    best_dist = tl.full([BLOCK_SIZE], float("inf"), dtype=tl.float32)
-    best_idx = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
-    for ic in range(0, N_CENTROIDS):
-        dist = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
-        for id in range(0, DIM):
-            x = tl.load(tensor_ptr + DIM * offs_n + id, mask=mask_n, other=0.0)
-            c = tl.load(centroids_ptr + DIM * ic + id)
-            delta = x.to(tl.float32) - c.to(tl.float32)
-            dist += delta * delta
+if triton is not None:
 
-        take = dist < best_dist
-        best_dist = tl.where(take, dist, best_dist)
-        best_idx = tl.where(take, ic, best_idx)
+    @triton.jit
+    def _kernel__nearest_neighbour_triton(
+        tensor_ptr,
+        centroids_ptr,
+        out_ptr,
+        n,
+        BLOCK_SIZE: tl.constexpr,
+        DIM: tl.constexpr,
+        N_CENTROIDS: tl.constexpr,
+    ) -> None:
+        pid = tl.program_id(axis=0)
+        offs_n = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask_n = offs_n < n
 
-    tl.store(out_ptr + offs_n, best_idx.to(tl.int64), mask=mask_n)
+        best_dist = tl.full([BLOCK_SIZE], float("inf"), dtype=tl.float32)
+        best_idx = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
+        for ic in range(0, N_CENTROIDS):
+            dist = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+            for id in range(0, DIM):
+                x = tl.load(tensor_ptr + DIM * offs_n + id, mask=mask_n, other=0.0)
+                c = tl.load(centroids_ptr + DIM * ic + id)
+                delta = x.to(tl.float32) - c.to(tl.float32)
+                dist += delta * delta
+
+            take = dist < best_dist
+            best_dist = tl.where(take, dist, best_dist)
+            best_idx = tl.where(take, ic, best_idx)
+
+        tl.store(out_ptr + offs_n, best_idx.to(tl.int64), mask=mask_n)
 
 
 _DEFAULT_BLOCK_SIZE = 1024
@@ -50,6 +57,9 @@ def nearest_neighbour_triton(
     out: Tensor | None = None,
     block_size: int = _DEFAULT_BLOCK_SIZE,
 ) -> Tensor:
+    if triton is None:
+        raise ImportError("triton is required for method='triton'")
+
     n, d = tensor.shape
     nc, dc = centroids.shape
     assert dc == d
@@ -109,7 +119,12 @@ def nearest_neighbour(
     if method == "auto":
         method = (
             "triton"
-            if tensor.is_cuda and centroids.is_cuda and centroids.size(-1) <= 256
+            if (
+                triton is not None
+                and tensor.is_cuda
+                and centroids.is_cuda
+                and centroids.size(-1) <= 256
+            )
             else "torch"
         )
     if method == "triton":


### PR DESCRIPTION
I was having issues submitting jobs from local machine due to the `triton` imports, so was wondering if we could inject this small patch. This is only to allow the jobs to be submitted from a machine with no `triton`, but should still execute `triton` code remotely.